### PR TITLE
Add decorate

### DIFF
--- a/lib/context/base_context.rb
+++ b/lib/context/base_context.rb
@@ -9,6 +9,15 @@ module Context
     class << self
       include Memoizer
 
+      def decorate(ancestor_context_method, decorator:, args: [])
+        define_method(ancestor_context_method) do
+          decorator.new(
+            @parent_context.public_send(ancestor_context_method),
+            *(args.map { |arg| instance_eval(arg.to_s) })
+          )
+        end
+      end
+
       def has_view_helper?(method_name)
         @view_helpers.is_a?(Array) && @view_helpers.include?(method_name.to_sym)
       end

--- a/lib/context/base_context.rb
+++ b/lib/context/base_context.rb
@@ -9,13 +9,15 @@ module Context
     class << self
       include Memoizer
 
-      def decorate(ancestor_context_method, decorator:, args: [])
+      def decorate(ancestor_context_method, decorator:, args: [], memoize: false)
         define_method(ancestor_context_method) do
           decorator.new(
             @parent_context.public_send(ancestor_context_method),
             *(args.map { |arg| instance_eval(arg.to_s) })
           )
         end
+
+        public_send(:memoize, ancestor_context_method) if memoize
       end
 
       def has_view_helper?(method_name)

--- a/lib/context/base_context.rb
+++ b/lib/context/base_context.rb
@@ -63,6 +63,10 @@ module Context
       @parent_context&.respond_to?(method_name, include_private)
     end
 
+    def whereis(method_name)
+      context_method_mapping[method_name.to_sym]
+    end
+
     private
 
     def get_context_method_mapping

--- a/lib/context/base_context.rb
+++ b/lib/context/base_context.rb
@@ -45,6 +45,12 @@ module Context
           @parent_context.has_view_helper?(method_name))
     end
 
+    def context_method_mapping
+      @context_method_mapping ||=
+        (@parent_context.try(:context_method_mapping) || {})
+          .merge(get_context_method_mapping)
+    end
+
     def method_missing(method_name, *args, &block)
       if @parent_context
         @parent_context.public_send(method_name, *args, &block)
@@ -55,6 +61,14 @@ module Context
 
     def respond_to_missing?(method_name, include_private = false)
       @parent_context&.respond_to?(method_name, include_private)
+    end
+
+    private
+
+    def get_context_method_mapping
+      self.class.public_instance_methods(false).reduce({}) do |hash, method_name|
+        hash.merge!(method_name => self.class.name)
+      end
     end
   end
 end

--- a/lib/context/base_context.rb
+++ b/lib/context/base_context.rb
@@ -34,6 +34,11 @@ module Context
       end
     end
 
+    def context_class_chain
+      @context_class_chain ||=
+        ((@parent_context.try(:context_class_chain) || []) + [self.class.name])
+    end
+
     def has_view_helper?(method_name)
       self.class.has_view_helper?(method_name) ||
         (@parent_context.present? &&

--- a/lib/context/version.rb
+++ b/lib/context/version.rb
@@ -1,3 +1,3 @@
 module Context
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/base_context_spec.rb
+++ b/spec/base_context_spec.rb
@@ -202,6 +202,33 @@ describe Context::BaseContext do
     end
   end
 
+  describe '#whereis' do
+    let(:instance) { TestContext.new }
+    let(:instance2) { TestContext2.wrap(instance) }
+    let(:instance3) { TestContext3.wrap(instance2) }
+
+    it 'returns the name of the context class in the chain where a method is '\
+    'defined' do
+      expect(instance3.whereis('foo=')).to eq('TestContext')
+      expect(instance3.whereis(:method2)).to eq('TestContext')
+      expect(instance3.whereis('blah')).to eq('TestContext2')
+      expect(instance3.whereis('alpha')).to eq('TestContext3')
+    end
+
+    it 'returns nil if the method is not a public method' do
+      expect(instance.instance_eval('protected_method'))
+        .to eq('protected_method')
+      expect(instance.whereis(:protected_method)).to eq(nil)
+
+      expect(instance.instance_eval('private_method')).to eq('private_method')
+      expect(instance.whereis(:private_method)).to eq(nil)
+    end
+
+    it 'returns nil if the method does not exist' do
+      expect(instance.whereis(:obladiblahda)).to eq(nil)
+    end
+  end
+
   describe 'method_missing' do
     let(:instance) { TestContext.new(foo: 1) }
     let(:instance2) { TestContext2.wrap(instance) }

--- a/spec/base_context_spec.rb
+++ b/spec/base_context_spec.rb
@@ -38,6 +38,9 @@ class TestContext2 < Context::BaseContext
 end
 
 class TestContext3 < Context::BaseContext
+  def alpha
+    'alpha'
+  end
 end
 
 describe Context::BaseContext do
@@ -147,6 +150,55 @@ describe Context::BaseContext do
     it 'is true if a grand-wrapped context has a declared view helper' do
       expect(instance3.has_view_helper?(:method1)).to eq(true)
       expect(instance3.has_view_helper?('method2')).to eq(true)
+    end
+  end
+
+  describe '#context_method_mapping' do
+    let(:instance) { TestContext.new }
+    let(:instance2) { TestContext2.wrap(instance) }
+    let(:instance3) { TestContext3.wrap(instance2) }
+
+    it 'returns a hash of public instance method names as keys and the '\
+    'context name as values' do
+      expect(instance.context_method_mapping).to eq(
+        {
+          :foo => 'TestContext',
+          :foo= => 'TestContext',
+          :method1 => 'TestContext',
+          :method2 => 'TestContext',
+          :method3 => 'TestContext'
+        }
+      )
+    end
+
+    it 'includes public instance methods from a wrapped context, with that '\
+    'wrapped context class name as the associated value for those methods' do
+      expect(instance2.context_method_mapping).to eq(
+        {
+          :blah => 'TestContext2',
+          :blah= => 'TestContext2',
+          :foo => 'TestContext',
+          :foo= => 'TestContext',
+          :method1 => 'TestContext',
+          :method2 => 'TestContext',
+          :method3 => 'TestContext'
+        }
+      )
+    end
+
+    it 'returns the expected values for multiple-wrapped contexts' do
+      expect(instance3.context_method_mapping).to eq(
+        {
+          :alpha => 'TestContext3',
+          :blah => 'TestContext2',
+          :blah= => 'TestContext2',
+          :foo => 'TestContext',
+          :foo= => 'TestContext',
+          :method1 => 'TestContext',
+          :method2 => 'TestContext',
+          :method3 => 'TestContext'
+        }
+      )
     end
   end
 

--- a/spec/base_context_spec.rb
+++ b/spec/base_context_spec.rb
@@ -109,6 +109,21 @@ describe Context::BaseContext do
     end
   end
 
+  describe '#context_class_chain' do
+    let(:instance) { TestContext.new(foo: 1) }
+    let(:instance2) { TestContext2.wrap(instance) }
+    let(:instance3) { TestContext3.wrap(instance2) }
+
+    it 'returns an array of all chained context class names in the order '\
+    'they were wrapped' do
+      expect(instance.context_class_chain).to eq(['TestContext'])
+      expect(instance2.context_class_chain)
+        .to eq(['TestContext', 'TestContext2'])
+      expect(instance3.context_class_chain)
+        .to eq(['TestContext', 'TestContext2', 'TestContext3'])
+    end
+  end
+
   describe '#has_view_helper?' do
     let(:instance) { TestContext.new(foo: 1) }
     let(:instance2) { TestContext2.wrap(instance) }


### PR DESCRIPTION
This PR adds several different interface elements to `BaseContext`:

* `context_class_chain` can be used to find out the set of all contexts that have been built up at any given time during a request cycle. It returns an array with these context class names in order.

* `context_method_mapping` provides a hash whose keys are all available methods coming from contexts, with the associated values being the names of the contexts where those methods  are defined.

* `whereis` is a convenience method to interface with `context_method_mapping` and get the context where a supplied method name is defined.

* `decorate` is an interface that allows a context to declare that a particular method arriving from an earlier context will be amended in the current context via the decorator pattern. It is intended to convey a clear intention on the part of the developer, and will, after later changes, be the only allowed situation where existing methods defined earlier in a context chain can be amended in a context.
