### PR TITLE
disallow overriding methods in contexts

### DIFF
--- a/lib/context/version.rb
+++ b/lib/context/version.rb
@@ -1,3 +1,3 @@
 module Context
-  VERSION = '0.2.0'
+  VERSION = '1.0.0'
 end

--- a/spec/base_context_spec.rb
+++ b/spec/base_context_spec.rb
@@ -140,6 +140,41 @@ describe Context::BaseContext do
       expect(contextA.foo).to eq(1)
       expect(contextB.foo).to eq(1)
     end
+
+    it 'raises a MethodOverrideError if a context attempts to overwrite a '\
+    'public instance method defined in a parent context' do
+      contextA = TestContext.new
+      other_context_class = Class.new(Context::BaseContext) do
+        def self.name
+          'BadContext'
+        end
+
+        def method1
+          'overwrite'
+        end
+      end
+
+      expect { other_context_class.wrap(contextA) }.to raise_error(
+        Context::MethodOverrideError,
+        'BadContext can not overwrite methods already defined in the '\
+        'context chain: [:method1]'
+      )
+    end
+
+    it 'allows overwriting non-public methods' do
+      contextA = TestContext.new
+      other_context_class = Class.new(Context::BaseContext) do
+        def private_method
+          'overwrite'
+        end
+
+        def protected_method
+          'overwrite'
+        end
+      end
+
+      expect { other_context_class.wrap(contextA) }.not_to raise_error
+    end
   end
 
   describe '.decorate is used in conjunction with `wrap` to provide an '\


### PR DESCRIPTION
Quoting from the primary commit message:

Prior to this commit, it was possible for contexts to override public
methods defined in previous contexts. This is an anti-pattern, because
one of the main goals of contexts is to tell a clear, linear story of
what is happening in a request. Overriding methods adds confusion, and
is a sign that contexts are being improperly used. This commit
explicitly prevents any context from overriding methods defined earlier
in the context chain. This happens at runtime when the `wrap` method is
called. If a method is found to be overwriting a previously-defined
public method, a `MethodOverrideError` exception is raised.

Two notes:

1. Methods that have been explicitly decorated using the `decorate`
   declaration are excluded from this constraint. Decoration is a valid
   use of contexts, and is not considered an anti-pattern. One of the
   reasons the `decorate` declaration was added before is that it
   signifies intent, and works within a clear and consistent interface
   pattern, which allows us to constrain the exception to that use case.

2. Non-public methods defined in a context are not subject to any of the
   constraints described above. A context can only access public methods
   of other contexts earlier in the chain, so those are the only ones
   that we care about constraining.