### PR TITLE
V1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+* Fix naming bug in BaseContextHelper
+
 ## [1.1.0]
 * Add method_missing logic to Context::Controller, so that controllers can
   easily access public methods in the context chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.1.1]
 * Fix naming bug in BaseContextHelper
 
 ## [1.1.0]

--- a/lib/context/base_context_helper.rb
+++ b/lib/context/base_context_helper.rb
@@ -1,15 +1,15 @@
 module Context
   module BaseContextHelper
     def method_missing(method_name, *args, &block)
-        if context && context.has_view_helper?(method_name)
-        context.public_send(method_name, *args, &block)
+        if @__context && @__context.has_view_helper?(method_name)
+        @__context.public_send(method_name, *args, &block)
       else
         super
       end
     end
 
     def respond_to_missing?(method_name, _include_private = false)
-      context.has_view_helper?(method_name)
+      @__context.has_view_helper?(method_name)
     end
   end
 end

--- a/lib/context/version.rb
+++ b/lib/context/version.rb
@@ -1,3 +1,3 @@
 module Context
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
This PR fixes a naming bug in `Context::BaseContextHelper`. It also updates the gem to version 1.1.1. Version 1.1.0 will be yanked from Rubygems. There aren't tests for the helper module, which is how this was missed earlier, but this is now been implicitly tested by the WegoWise app, which is currently referencing this branch and has all tests passing.